### PR TITLE
added sliding-window functions sliding and slidingWithSizeAndStep

### DIFF
--- a/test/Test/Data/Array.purs
+++ b/test/Test/Data/Array.purs
@@ -467,6 +467,21 @@ testArray = do
     , [4,0,0,1,25,36,458,5842,23757]
     ]
 
+  log "sliding"
+  assert $ A.sliding [ 1, 2, 3, 4, 5 ] == [ (Tuple 1 2), (Tuple 2 3), (Tuple 3 4), (Tuple 4 5) ]
+
+  log "slidingWithStepAndSize"
+  assert $ A.slidingWithSizeAndStep 3 2 (A.range 0 10) == [[0,1,2],[2,3,4],[4,5,6],[6,7,8],[8,9,10],[10]]
+  assert $ A.slidingWithSizeAndStep 3 3 (A.range 0 10) == [[0,1,2],[3,4,5],[6,7,8],[9,10]]
+  assert $ A.slidingWithSizeAndStep 3 (-2) (A.range 0 10) == []
+  assert $ A.slidingWithSizeAndStep (-3) (2) (A.range 0 10) == []
+
+  log "rangeWithStep"
+  assert $ A.rangeWithStep 0 6 2 == [ 0, 2, 4, 6 ]
+  assert $ A.rangeWithStep 0 (-6) (-2) == [ 0, -2, -4, -6 ]
+  assert $ A.rangeWithStep 0 6 (-2) == []
+  assert $ A.rangeWithStep 0 (-6) (2) == []
+
 nea :: Array ~> NEA.NonEmptyArray
 nea = unsafePartial fromJust <<< NEA.fromArray
 


### PR DESCRIPTION
Added the functions `sliding` and `slidingWithSizeAndStep` to allow sliding-window computations. In order to realise the `slidingWithSizeAndStep` I added `rangeWithStep`. 

I decided to have the functions return empty arrays in case the user gave them nonsensical arguments. Can change that to `Maybe` if that's preferred.
